### PR TITLE
[AE-1917] Provide RPM build for Maven 3.3.9

### DIFF
--- a/scripts/setup_env.sh
+++ b/scripts/setup_env.sh
@@ -28,10 +28,7 @@ if [ "x${YOURCOMPONENT}" = "x" ] ; then
 fi
 
 if [ "x${YOURCOMPONENT_VERSION}" = "x" ] ; then
-  export YOURCOMPONENT_VERSION=3.3.3
-fi
-if [ "x${ALTISCALE_RELEASE}" = "x" ] ; then
-  export ALTISCALE_RELEASE=3.0.0
+  export YOURCOMPONENT_VERSION=3.3.9
 fi
 
 # The build time here is part of the release number


### PR DESCRIPTION
Simply update the version value to `YOURCOMPONENT_VERSION=3.3.9` in `scripts/setup_env.sh`.

I have also remove ALTISCALE_RELEASE variable which is irrelevant.
